### PR TITLE
Fix after `type Uniq = Integer` patch

### DIFF
--- a/compiler/hsSyn/Convert.hs
+++ b/compiler/hsSyn/Convert.hs
@@ -1811,8 +1811,8 @@ thRdrName loc ctxt_ns th_occ th_name
   = case th_name of
      TH.NameG th_ns pkg mod -> thOrigRdrName th_occ th_ns pkg mod
      TH.NameQ mod  -> (mkRdrQual  $! mk_mod mod) $! occ
-     TH.NameL uniq -> nameRdrName $! (((Name.mkInternalName $! mk_uniq (fromInteger uniq)) $! occ) loc)
-     TH.NameU uniq -> nameRdrName $! (((Name.mkSystemNameAt $! mk_uniq (fromInteger uniq)) $! occ) loc)
+     TH.NameL uniq -> nameRdrName $! (((Name.mkInternalName $! mk_uniq (fromIntegral uniq)) $! occ) loc)
+     TH.NameU uniq -> nameRdrName $! (((Name.mkSystemNameAt $! mk_uniq (fromIntegral uniq)) $! occ) loc)
      TH.NameS | Just name <- isBuiltInOcc_maybe occ -> nameRdrName $! name
               | otherwise                           -> mkRdrUnqual $! occ
               -- We check for built-in syntax here, because the TH

--- a/compiler/typecheck/TcSplice.hs
+++ b/compiler/typecheck/TcSplice.hs
@@ -920,7 +920,7 @@ To call runQ in the Tc monad, we need to make TcM an instance of Quasi:
 instance TH.Quasi TcM where
   qNewName s = do { u <- newUnique
                   ; let i = toInteger (getKey u)
-                  ; return (TH.mkNameU s i) }
+                  ; return (TH.mkNameU s (fromIntegral i)) }
 
   -- 'msg' is forced to ensure exceptions don't escape,
   -- see Note [Exceptions in TH]
@@ -2037,7 +2037,7 @@ reifyName :: NamedThing n => n -> TH.Name
 reifyName thing
   | isExternalName name
               = mk_varg pkg_str mod_str occ_str
-  | otherwise = TH.mkNameU occ_str (toInteger $ getKey (getUnique name))
+  | otherwise = TH.mkNameU occ_str (fromIntegral $ getKey (getUnique name))
         -- Many of the things we reify have local bindings, and
         -- NameL's aren't supposed to appear in binding positions, so
         -- we use NameU.  When/if we start to reify nested things, that


### PR DESCRIPTION
Previous patch made `type Uniq = Integer` (instead of `Int`). This fixes
the build